### PR TITLE
Potential fix for code scanning alert no. 12: Inefficient regular expression

### DIFF
--- a/public/assets/scripts/main.js
+++ b/public/assets/scripts/main.js
@@ -43,7 +43,7 @@ const replacer = (m, p1, p2, p3, p4, p5) => {
 
 const getRGB = (me) => {
   var rgbValue = me.css('background'),
-    rgbRule = rgbValue.replace(/(^.*?)(rgb\()(\d*, \d*, \d*)+(\))(.*?$)/i, replacer),
+    rgbRule = rgbValue.replace(/(^.*?)(rgb\()(\d+, \d+, \d+)(\))(.*?$)/i, replacer),
     rgbSplit = rgbRule.split(',');
 
   if (rgbSplit.length === 3) {


### PR DESCRIPTION
Potential fix for [https://github.com/raphievila/rgb-palette/security/code-scanning/12](https://github.com/raphievila/rgb-palette/security/code-scanning/12)

To fix the issue, we need to rewrite the regular expression to eliminate the ambiguity in the sub-expression `(\d*, \d*, \d*)+`. Specifically, we can replace `\d*` with `\d+`, ensuring that each number in the sequence has at least one digit. This change removes the possibility of matching zero digits, which is the source of the ambiguity. Additionally, we can make the pattern more robust by explicitly matching the expected format of the RGB values.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
